### PR TITLE
add command suggestions

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -206,6 +206,16 @@ type Environment struct {
 	// been executed. The no-op implementation is `return cmd.Execute(ctx)`.
 	Wrap func(ctx Context, cmd Command) (err error)
 
+	// SuggestionsMinEditDistance defines minimum Levenshtein distance to
+	// display suggestions when a command/subcommand is misspelled.
+	// Must be > 0.
+	// Default is 2
+	SuggestionsMinEditDistance int
+
+	// 	DisableSuggestions disables the suggestions based on Levenshtein
+	//	distance that go along with 'unknown command' messages
+	DisableSuggestions bool
+
 	Stdin  io.Reader // Stdin defaults to os.Stdin if unset.
 	Stdout io.Writer // Stdout defaults to os.Stdout if unset.
 	Stderr io.Writer // Stderr defaults to os.Stderr if unset.

--- a/run.go
+++ b/run.go
@@ -33,7 +33,7 @@ func (env Environment) Run(ctx context.Context, fn func(Commands)) (bool, error)
 
 	ok, err := env.dispatch(ctx, st, descs)
 	if !ok {
-		env.appendUnknownCommandError(st)
+		env.appendUnknownCommandErrorWithSuggestions(st, descs)
 		env.printUsage(ctx, st, cmdDesc{subcmds: descs})
 	}
 	return len(st.errors) == 0, err
@@ -100,7 +100,7 @@ func (env *Environment) dispatchDesc(ctx context.Context, st *runState, desc cmd
 	// specified the wrong name, and error if so.
 	if desc.cmd == nil {
 		if len(desc.subcmds) > 0 {
-			env.appendUnknownCommandError(st)
+			env.appendUnknownCommandErrorWithSuggestions(st, desc.subcmds)
 		}
 		env.printUsage(ctx, st, desc)
 		return true, nil

--- a/suggestion.go
+++ b/suggestion.go
@@ -1,0 +1,82 @@
+package clingy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/zeebo/errs/v2"
+)
+
+func (env *Environment) appendUnknownCommandErrorWithSuggestions(st *runState, descs []cmdDesc) {
+	if env.DisableSuggestions {
+		env.appendUnknownCommandError(st)
+		return
+	}
+
+	if env.SuggestionsMinEditDistance <= 0 {
+		env.SuggestionsMinEditDistance = 2
+	}
+
+	name, ok, err := st.peekName()
+	if ok {
+		suggestionsString := fmt.Sprintf("%q for %q", name, st.name())
+		if suggestions := suggestionsFor(name, descs, env.SuggestionsMinEditDistance); len(suggestions) > 0 {
+			suggestionsString += "\n\n\tMaybe you meant:\n"
+			for _, s := range suggestions {
+				suggestionsString += fmt.Sprintf("\t\t%v\n", s)
+			}
+		}
+
+		st.errors = append(st.errors, errs.Tag("unknown command").Errorf("%s", suggestionsString))
+	}
+	if err != nil {
+		st.errors = append(st.errors, err)
+	}
+}
+
+func suggestionsFor(typedCmd string, cmds []cmdDesc, distance int) []string {
+	suggestions := []string{}
+	for _, cmd := range cmds {
+		levenshteinDistance := levenshteinDistance(typedCmd, cmd.name)
+		suggestByLevenshtein := levenshteinDistance <= distance
+		suggestByPrefix := strings.HasPrefix(strings.ToLower(cmd.name), strings.ToLower(typedCmd))
+		if suggestByLevenshtein || suggestByPrefix {
+			suggestions = append(suggestions, cmd.name)
+		}
+	}
+	return suggestions
+}
+
+// levenshteinDistance compares two strings and returns the Levenshtein Distance between them.
+func levenshteinDistance(a, b string) int {
+	a = strings.ToLower(a)
+	b = strings.ToLower(b)
+
+	d := make([][]int, len(a)+1)
+	for i := range d {
+		d[i] = make([]int, len(b)+1)
+	}
+	for i := range d {
+		d[i][0] = i
+	}
+	for j := range d[0] {
+		d[0][j] = j
+	}
+	for j := 1; j <= len(b); j++ {
+		for i := 1; i <= len(a); i++ {
+			if a[i-1] == b[j-1] {
+				d[i][j] = d[i-1][j-1]
+			} else {
+				min := d[i-1][j]
+				if d[i][j-1] < min {
+					min = d[i][j-1]
+				}
+				if d[i-1][j-1] < min {
+					min = d[i-1][j-1]
+				}
+				d[i][j] = min + 1
+			}
+		}
+	}
+	return d[len(a)][len(b)]
+}

--- a/suggestion_test.go
+++ b/suggestion_test.go
@@ -1,0 +1,71 @@
+package clingy
+
+import "testing"
+
+func Test_levenshteinDistance(t *testing.T) {
+	type args struct {
+		a string
+		b string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "different strings 1",
+			args: args{
+				a: "Sitting",
+				b: "Kitten",
+			},
+			want: 3,
+		},
+		{
+			name: "different strings 2",
+			args: args{
+				a: "Sunday",
+				b: "Saturday",
+			},
+			want: 3,
+		},
+		{
+			name: "strings are the same",
+			args: args{
+				a: "Sunday",
+				b: "Sunday",
+			},
+			want: 0,
+		},
+		{
+			name: "different strings 3",
+			args: args{
+				a: "abcdefgh",
+				b: "abcxdefghi",
+			},
+			want: 2,
+		},
+		{
+			name: "with numbers",
+			args: args{
+				a: "123456",
+				b: "234156",
+			},
+			want: 2,
+		},
+		{
+			name: "with numbers 2",
+			args: args{
+				a: "123657",
+				b: "123",
+			},
+			want: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := levenshteinDistance(tt.args.a, tt.args.b); got != tt.want {
+				t.Errorf("EditDistance() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds command suggestions for cases when a command or subcommand is misspelled.

It suggests available commands using the Levenshtein Distance Algorithm by finding the minimum distance between the typed command and the available commands


Examples:
```sh
➜  uplinkng access re
Errors:
    unknown command: "re" for "uplink access"

    Maybe you meant:
        restrict
        use
        revoke
        register


Usage:
    uplink access [command]

    Access related commands

Available commands:
    save        Save an existing access
    create      Create an access from a setup token
    delete      Delete an access from local store
    restrict    Restrict an access
    list        List saved accesses
    use         Set default access to use
    revoke      Revoke an access
    inspect     Inspect allows you to explode a serialized access into its constituent parts
    register    Register an access grant for use with a hosted S3 compatible gateway and linksharing

Global flags:
        --config-dir string    Directory that stores the configuration (default "/Users/profclems/Library/Application Support/Storj/Uplink")
    -h, --help                 prints help for the command
        --advanced             when used with -h, prints advanced flags help

Use "uplink access [command] --help" for more information about a command.
```