### PR TITLE
Return error code if command is missing

### DIFF
--- a/run.go
+++ b/run.go
@@ -36,7 +36,7 @@ func (env Environment) Run(ctx context.Context, fn func(Commands)) (bool, error)
 		env.appendUnknownCommandErrorWithSuggestions(st, descs)
 		env.printUsage(ctx, st, cmdDesc{subcmds: descs})
 	}
-	return len(st.errors) == 0, err
+	return ok && len(st.errors) == 0, err
 }
 
 func (env *Environment) dispatch(ctx context.Context, st *runState, descs []cmdDesc) (bool, error) {
@@ -106,7 +106,7 @@ func (env *Environment) dispatchDesc(ctx context.Context, st *runState, desc cmd
 			env.appendUnknownCommandErrorWithSuggestions(st, desc.subcmds)
 		}
 		env.printUsage(ctx, st, desc)
-		return true, nil
+		return false, nil
 	}
 
 	// print usage if requested


### PR DESCRIPTION
Previously if no subcommand was given the application returned 0 which
indicates success. So this is the case where you run a cli command with
no arguments or an argument which resolves to a command group.

With this change it will return error code 1. This seems more useful and
conventional.

As an aside, it seems impossible to register a handler for the top-level
command. For example it's not possible to implement "ls" with clingy.