### PR TITLE
Print expected arg type on non-bstyle bool flags

### DIFF
--- a/params.go
+++ b/params.go
@@ -47,10 +47,10 @@ func (p *param) flagType() string {
 	if p.paramOpts.typ != "" {
 		return p.paramOpts.typ
 	}
-	switch p.typ {
-	case boolType:
+	switch {
+	case p.typ == boolType && p.bstyle:
 		return ""
-	case durationType:
+	case p.typ == durationType:
 		return "duration"
 	default:
 		return p.typ.Name()

--- a/usage.go
+++ b/usage.go
@@ -38,6 +38,13 @@ func printUsagePrefix(ctx context.Context, w io.Writer, st *runState, desc cmdDe
 	fmt.Fprintf(w, "Usage:\n")
 	fmt.Fprintf(w, "\t%s", st.name())
 
+	padLeft := func(s string) string {
+		if s != "" {
+			return " " + s
+		}
+		return ""
+	}
+
 	req := 0
 	st.flags.params(func(p *param) {
 		if p == nil || p.hidden {
@@ -51,11 +58,9 @@ func printUsagePrefix(ctx context.Context, w io.Writer, st *runState, desc cmdDe
 			return
 		}
 		if p.rep {
-			fmt.Fprintf(w, " %c--%s %s ...%c", chars[0], p.name, p.flagType(), chars[1])
-		} else if typ := p.flagType(); typ != "" {
-			fmt.Fprintf(w, " %c--%s %s%c", chars[0], p.name, p.flagType(), chars[1])
+			fmt.Fprintf(w, " %c--%s%s ...%c", chars[0], p.name, padLeft(p.flagType()), chars[1])
 		} else {
-			fmt.Fprintf(w, " %c--%s%c", chars[0], p.name, chars[1])
+			fmt.Fprintf(w, " %c--%s%s%c", chars[0], p.name, padLeft(p.flagType()), chars[1])
 		}
 	})
 	if !st.advanced && st.flags.getCount()-req > 0 {

--- a/usage_test.go
+++ b/usage_test.go
@@ -22,18 +22,21 @@ func TestUsage_Exhaustive(t *testing.T) {
 
 			_ = params.Flag("Flags.ValString", desc(), "").(string)
 			_ = params.Flag("Flags.ValInt", desc(), 0, parseInt).(int)
-			_ = params.Flag("Flags.ValBool", desc(), false, clingy.Boolean, parseBool).(bool)
+			_ = params.Flag("Flags.ValBool", desc(), false, parseBool).(bool)
+			_ = params.Flag("Flags.ValBoolB", desc(), false, clingy.Boolean, parseBool).(bool)
 			_ = params.Flag("Flags.ValDur", desc(), time.Duration(0), parseDuration).(time.Duration)
 
 			params.Break()
 			_ = params.Flag("Flags.OptString", desc(), (*string)(nil), clingy.Optional).(*string)
 			_ = params.Flag("Flags.OptInt", desc(), (*int)(nil), clingy.Optional, parseInt).(*int)
-			_ = params.Flag("Flags.OptBool", desc(), (*bool)(nil), clingy.Optional, clingy.Boolean, parseBool).(*bool)
+			_ = params.Flag("Flags.OptBool", desc(), (*bool)(nil), clingy.Optional, parseBool).(*bool)
+			_ = params.Flag("Flags.OptBoolB", desc(), (*bool)(nil), clingy.Optional, clingy.Boolean, parseBool).(*bool)
 
 			params.Break()
 			_ = params.Flag("Flags.RepString", desc(), []string(nil), clingy.Repeated).([]string)
 			_ = params.Flag("Flags.RepInt", desc(), []int(nil), clingy.Repeated, parseInt).([]int)
-			_ = params.Flag("Flags.RepBool", desc(), []bool(nil), clingy.Repeated, clingy.Boolean, parseBool).([]bool)
+			_ = params.Flag("Flags.RepBool", desc(), []bool(nil), clingy.Repeated, parseBool).([]bool)
+			_ = params.Flag("Flags.RepBoolB", desc(), []bool(nil), clingy.Repeated, clingy.Boolean, parseBool).([]bool)
 
 			params.Break()
 			_ = params.Flag("Flags.Def", desc(), "some default").(string)
@@ -54,7 +57,8 @@ func TestUsage_Exhaustive(t *testing.T) {
 
 			_ = params.Flag("Flags.HiddenString", "", "", clingy.Hidden).(string)
 			_ = params.Flag("Flags.HiddenInt", "", 0, parseInt, clingy.Hidden).(int)
-			_ = params.Flag("Flags.HiddenBool", "", false, clingy.Boolean, parseBool, clingy.Hidden).(bool)
+			_ = params.Flag("Flags.HiddenBool", "", false, parseBool, clingy.Hidden).(bool)
+			_ = params.Flag("Flags.HiddenBoolB", "", false, clingy.Boolean, parseBool, clingy.Hidden).(bool)
 
 			_ = params.Arg("Args.ValString", desc()).(string)
 			_ = params.Arg("Args.ValInt", desc(), parseInt).(int)
@@ -68,7 +72,7 @@ func TestUsage_Exhaustive(t *testing.T) {
 		ExecuteFn: func(ctx context.Context) error { return nil },
 	}
 
-	{
+	t.Run("normal", func(t *testing.T) {
 		result := Run(root, "-h")
 		result.AssertValid(t)
 		result.AssertStdout(t, `
@@ -76,94 +80,100 @@ func TestUsage_Exhaustive(t *testing.T) {
 			    testcommand <--Flags.Req string> <--Flags.ReqRep string ...> <--Flags.ReqEnv string> <--Flags.ReqRepEnv string ...> [flags] <Args.ValString> <Args.ValInt> [Args.OptString [Args.OptInt [Args.RepInt ...]]]
 
 			Arguments:
-			    Args.ValString    desc 22
-			    Args.ValInt       desc 23
-			    Args.OptString    desc 24
-			    Args.OptInt       desc 25
-			    Args.RepInt       desc 26
+			    Args.ValString    desc 25
+			    Args.ValInt       desc 26
+			    Args.OptString    desc 27
+			    Args.OptInt       desc 28
+			    Args.RepInt       desc 29
 
 			Flags:
 			        --Flags.ValString string    desc 1
 			        --Flags.ValInt int          desc 2
-			        --Flags.ValBool             desc 3
-			        --Flags.ValDur duration     desc 4
+			        --Flags.ValBool bool        desc 3
+			        --Flags.ValBoolB            desc 4
+			        --Flags.ValDur duration     desc 5
 
-			        --Flags.OptString string    desc 5
-			        --Flags.OptInt int          desc 6
-			        --Flags.OptBool             desc 7
+			        --Flags.OptString string    desc 6
+			        --Flags.OptInt int          desc 7
+			        --Flags.OptBool bool        desc 8
+			        --Flags.OptBoolB            desc 9
 
-			        --Flags.RepString string    desc 8 (repeated)
-			        --Flags.RepInt int          desc 9 (repeated)
-			        --Flags.RepBool             desc 10 (repeated)
+			        --Flags.RepString string    desc 10 (repeated)
+			        --Flags.RepInt int          desc 11 (repeated)
+			        --Flags.RepBool bool        desc 12 (repeated)
+			        --Flags.RepBoolB            desc 13 (repeated)
 
-			        --Flags.Def string          desc 11 (default "some default")
-			        --Flags.DefRep string       desc 12 (repeated) (default [some default])
-			        --Flags.DefEnv string       desc 13 (env ENV) (default "some default")
-			        --Flags.DefRepEnv string    desc 14 (repeated) (env ENV) (default [some default])
+			        --Flags.Def string          desc 14 (default "some default")
+			        --Flags.DefRep string       desc 15 (repeated) (default [some default])
+			        --Flags.DefEnv string       desc 16 (env ENV) (default "some default")
+			        --Flags.DefRepEnv string    desc 17 (repeated) (env ENV) (default [some default])
 
-			        --Flags.Req string          desc 15 (required)
-			        --Flags.ReqRep string       desc 16 (required) (repeated)
-			        --Flags.ReqEnv string       desc 17 (required) (env ENV)
-			        --Flags.ReqRepEnv string    desc 18 (required) (repeated) (env ENV)
+			        --Flags.Req string          desc 18 (required)
+			        --Flags.ReqRep string       desc 19 (required) (repeated)
+			        --Flags.ReqEnv string       desc 20 (required) (env ENV)
+			        --Flags.ReqRepEnv string    desc 21 (required) (repeated) (env ENV)
 
-			        --Flags.Custom custom    desc 19
-			    -s, --Flags.Short string     desc 20
+			        --Flags.Custom custom    desc 22
+			    -s, --Flags.Short string     desc 23
 
 			Global flags:
 			    -h, --help         prints help for the command
 			        --summary      prints a summary of what commands are available
 			        --advanced     when used with -h, prints advanced flags help
 		`)
-	}
+	})
 
-	{
+	t.Run("advanced", func(t *testing.T) {
 		result := Run(root, "-h", "--advanced")
 		result.AssertValid(t)
 		result.AssertStdout(t, `
 			Usage:
-			    testcommand [--Flags.ValString string] [--Flags.ValInt int] [--Flags.ValBool] [--Flags.ValDur duration] [--Flags.OptString string] [--Flags.OptInt int] [--Flags.OptBool] [--Flags.RepString string ...] [--Flags.RepInt int ...] [--Flags.RepBool  ...] [--Flags.Def string] [--Flags.DefRep string ...] [--Flags.DefEnv string] [--Flags.DefRepEnv string ...] <--Flags.Req string> <--Flags.ReqRep string ...> <--Flags.ReqEnv string> <--Flags.ReqRepEnv string ...> [--Flags.Custom custom] [--Flags.Short string] [--Flags.Advanced string] <Args.ValString> <Args.ValInt> [Args.OptString [Args.OptInt [Args.RepInt ...]]]
+			    testcommand [--Flags.ValString string] [--Flags.ValInt int] [--Flags.ValBool bool] [--Flags.ValBoolB] [--Flags.ValDur duration] [--Flags.OptString string] [--Flags.OptInt int] [--Flags.OptBool bool] [--Flags.OptBoolB] [--Flags.RepString string ...] [--Flags.RepInt int ...] [--Flags.RepBool bool ...] [--Flags.RepBoolB ...] [--Flags.Def string] [--Flags.DefRep string ...] [--Flags.DefEnv string] [--Flags.DefRepEnv string ...] <--Flags.Req string> <--Flags.ReqRep string ...> <--Flags.ReqEnv string> <--Flags.ReqRepEnv string ...> [--Flags.Custom custom] [--Flags.Short string] [--Flags.Advanced string] <Args.ValString> <Args.ValInt> [Args.OptString [Args.OptInt [Args.RepInt ...]]]
 
 			Arguments:
-			    Args.ValString    desc 22
-			    Args.ValInt       desc 23
-			    Args.OptString    desc 24
-			    Args.OptInt       desc 25
-			    Args.RepInt       desc 26
+			    Args.ValString    desc 25
+			    Args.ValInt       desc 26
+			    Args.OptString    desc 27
+			    Args.OptInt       desc 28
+			    Args.RepInt       desc 29
 
 			Flags:
 			        --Flags.ValString string    desc 1
 			        --Flags.ValInt int          desc 2
-			        --Flags.ValBool             desc 3
-			        --Flags.ValDur duration     desc 4
+			        --Flags.ValBool bool        desc 3
+			        --Flags.ValBoolB            desc 4
+			        --Flags.ValDur duration     desc 5
 
-			        --Flags.OptString string    desc 5
-			        --Flags.OptInt int          desc 6
-			        --Flags.OptBool             desc 7
+			        --Flags.OptString string    desc 6
+			        --Flags.OptInt int          desc 7
+			        --Flags.OptBool bool        desc 8
+			        --Flags.OptBoolB            desc 9
 
-			        --Flags.RepString string    desc 8 (repeated)
-			        --Flags.RepInt int          desc 9 (repeated)
-			        --Flags.RepBool             desc 10 (repeated)
+			        --Flags.RepString string    desc 10 (repeated)
+			        --Flags.RepInt int          desc 11 (repeated)
+			        --Flags.RepBool bool        desc 12 (repeated)
+			        --Flags.RepBoolB            desc 13 (repeated)
 
-			        --Flags.Def string          desc 11 (default "some default")
-			        --Flags.DefRep string       desc 12 (repeated) (default [some default])
-			        --Flags.DefEnv string       desc 13 (env ENV) (default "some default")
-			        --Flags.DefRepEnv string    desc 14 (repeated) (env ENV) (default [some default])
+			        --Flags.Def string          desc 14 (default "some default")
+			        --Flags.DefRep string       desc 15 (repeated) (default [some default])
+			        --Flags.DefEnv string       desc 16 (env ENV) (default "some default")
+			        --Flags.DefRepEnv string    desc 17 (repeated) (env ENV) (default [some default])
 
-			        --Flags.Req string          desc 15 (required)
-			        --Flags.ReqRep string       desc 16 (required) (repeated)
-			        --Flags.ReqEnv string       desc 17 (required) (env ENV)
-			        --Flags.ReqRepEnv string    desc 18 (required) (repeated) (env ENV)
+			        --Flags.Req string          desc 18 (required)
+			        --Flags.ReqRep string       desc 19 (required) (repeated)
+			        --Flags.ReqEnv string       desc 20 (required) (env ENV)
+			        --Flags.ReqRepEnv string    desc 21 (required) (repeated) (env ENV)
 
-			        --Flags.Custom custom      desc 19
-			    -s, --Flags.Short string       desc 20
-			        --Flags.Advanced string    desc 21
+			        --Flags.Custom custom      desc 22
+			    -s, --Flags.Short string       desc 23
+			        --Flags.Advanced string    desc 24
 
 			Global flags:
 			    -h, --help         prints help for the command
 			        --summary      prints a summary of what commands are available
 			        --advanced     when used with -h, prints advanced flags help
 		`)
-	}
+	})
 }
 
 func TestUsage_MultilineDescription(t *testing.T) {


### PR DESCRIPTION
Non-bstyle boolean flags read the next argument to determine the flag value. The usage text does not reflect that though so it can be confusing to know when you need to pass the additional arg.

This PR updates the usage text to show the "bool" arg in the usage text for these kinds of flags.