### PR TITLE
Use base of Args[0] for name

### DIFF
--- a/run.go
+++ b/run.go
@@ -3,13 +3,14 @@ package clingy
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/zeebo/errs/v2"
 )
 
 func (env *Environment) fillDefaults() {
 	if env.Name == "" {
-		env.Name = os.Args[0]
+		env.Name = filepath.Base(os.Args[0])
 	}
 	if env.Args == nil {
 		env.Args = os.Args[1:]


### PR DESCRIPTION
Otherwise you get all of the path you used to invoke the command printed as the name:

e.g., /var/folders/blah/blah/blah/some-binary when running to `go run . --help`